### PR TITLE
ODP-2769 : Refactor shebangs for python scripts to ambari-python-wrap

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-monitoring/check_zookeeper.py
+++ b/zookeeper-contrib/zookeeper-contrib-monitoring/check_zookeeper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/zookeeper-contrib/zookeeper-contrib-monitoring/test.py
+++ b/zookeeper-contrib/zookeeper-contrib-monitoring/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/zookeeper-contrib/zookeeper-contrib-rest/src/python/demo_master_election.py
+++ b/zookeeper-contrib/zookeeper-contrib-rest/src/python/demo_master_election.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-rest/src/python/demo_queue.py
+++ b/zookeeper-contrib/zookeeper-contrib-rest/src/python/demo_queue.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-rest/src/python/test.py
+++ b/zookeeper-contrib/zookeeper-contrib-rest/src/python/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-rest/src/python/zk_dump_tree.py
+++ b/zookeeper-contrib/zookeeper-contrib-rest/src/python/zk_dump_tree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/examples/watch_znode_for_changes.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/examples/watch_znode_for_changes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env ambari-python-wrap
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/acl_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/acl_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/async_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/async_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/callback_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/callback_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/clientid_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/clientid_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/close_deadlock_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/close_deadlock_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/connection_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/connection_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/create_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/create_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/delete_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/delete_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/exists_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/exists_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/get_set_test.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/get_set_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/run_tests.sh
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/run_tests.sh
@@ -36,5 +36,5 @@ LIB_PATH=../../build/c/.libs/:../../build/test/test-cppunit/.libs
 for test in `ls $1/*_test.py`; 
 do
     echo "Running $test"
-    LD_LIBRARY_PATH=$LIB_PATH:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$LIB_PATH:$DYLD_LIBRARY_PATH PYTHONPATH=$PYTHONPATH python $test
+    LD_LIBRARY_PATH=$LIB_PATH:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$LIB_PATH:$DYLD_LIBRARY_PATH PYTHONPATH=$PYTHONPATH ambari-python-wrap $test
 done

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/zktestbase.py
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/test/zktestbase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/zookeeper-server/src/test/resources/check_compatibility.py
+++ b/zookeeper-server/src/test/resources/check_compatibility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
ODP-2769 : Refactor shebangs for python scripts to ambari-python-wrap

Tested in RHEL9, RHEL8, UBUNTU22