### PR TITLE
ODP-3573 | ZOOKEEPER-4891: Rollback logback-classic to 1.3.x for jdk8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
 
     <!-- dependency versions -->
     <slf4j.version>2.0.16</slf4j.version>
-    <logback-version>1.5.16</logback-version>
+    <logback-version>1.3.15</logback-version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
[ZOOKEEPER-4891](https://issues.apache.org/jira/browse/ZOOKEEPER-4891): Update logback to 1.3.15 to fix https://github.com/advisories/GHSA-pr98-23f8-jwxv.