### PR TITLE
OSV-23899 - CVE - Bumping-up netty-codec to 4.1.135.Final to fix CVE-2026-42583

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
     <mockito.version>4.9.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <jetty.version>9.4.57.v20241219</jetty.version>
     <jackson.version>2.18.6</jackson.version>
     <jline.version>2.14.6</jline.version>


### PR DESCRIPTION
Bumps netty.version 4.1.132.Final -> 4.1.135.Final to fix CVE-2026-42583 (Netty Lz4FrameDecoder resource exhaustion). Required fix version was 4.1.133.Final; bumping to 4.1.135.Final per request (supersedes minimum fix). Built and verified with JDK 1.8 (mvn clean install -DskipTests -Pfull-build) - BUILD SUCCESS.